### PR TITLE
Replace native "events" package by pure js implementation

### DIFF
--- a/nunjucks/src/object.js
+++ b/nunjucks/src/object.js
@@ -1,7 +1,7 @@
 'use strict';
 
 // A simple class system, more documentation to come
-const EventEmitter = require('events');
+const EventEmitter = require('jsEvents');
 const lib = require('./lib');
 
 function parentWrap(parent, prop) {

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "dependencies": {
     "a-sync-waterfall": "^1.0.0",
     "asap": "^2.0.3",
-    "commander": "^5.1.0"
+    "commander": "^5.1.0",
+    "jsEvents": "npm:events@^3.2.0"
   },
   "browser": "./browser/nunjucks.js",
   "devDependencies": {


### PR DESCRIPTION
This is necessary as we plan to use nunjucks in vm2, were loading of
native nodejs libraries is [currently limited](https://github.com/patriksimek/vm2/issues/216).

