### PR TITLE
Remove "fs" dependency

### DIFF
--- a/nunjucks/src/node-loaders.js
+++ b/nunjucks/src/node-loaders.js
@@ -2,7 +2,6 @@
 
 'use strict';
 
-const fs = require('fs');
 const path = require('path');
 const Loader = require('./loader');
 const {PrecompiledLoader} = require('./precompiled-loader.js');
@@ -32,56 +31,12 @@ class FileSystemLoader extends Loader {
     }
 
     if (opts.watch) {
-      // Watch all the templates in the paths and fire an event when
-      // they change
-      try {
-        chokidar = require('chokidar'); // eslint-disable-line global-require
-      } catch (e) {
-        throw new Error('watch requires chokidar to be installed');
-      }
-      const paths = this.searchPaths.filter(fs.existsSync);
-      const watcher = chokidar.watch(paths);
-      watcher.on('all', (event, fullname) => {
-        fullname = path.resolve(fullname);
-        if (event === 'change' && fullname in this.pathsToNames) {
-          this.emit('update', this.pathsToNames[fullname], fullname);
-        }
-      });
-      watcher.on('error', (error) => {
-        console.log('Watcher error: ' + error);
-      });
+      throw new Error('Filesystem operations are not supported.');
     }
   }
 
   getSource(name) {
-    var fullpath = null;
-    var paths = this.searchPaths;
-
-    for (let i = 0; i < paths.length; i++) {
-      const basePath = path.resolve(paths[i]);
-      const p = path.resolve(paths[i], name);
-
-      // Only allow the current directory and anything
-      // underneath it to be searched
-      if (p.indexOf(basePath) === 0 && fs.existsSync(p)) {
-        fullpath = p;
-        break;
-      }
-    }
-
-    if (!fullpath) {
-      return null;
-    }
-
-    this.pathsToNames[fullpath] = name;
-
-    const source = {
-      src: fs.readFileSync(fullpath, 'utf-8'),
-      path: fullpath,
-      noCache: this.noCache
-    };
-    this.emit('load', name, source);
-    return source;
+    throw new Error('Filesystem operations are not supported.');
   }
 }
 
@@ -114,32 +69,7 @@ class NodeResolveLoader extends Loader {
   }
 
   getSource(name) {
-    // Don't allow file-system traversal
-    if ((/^\.?\.?(\/|\\)/).test(name)) {
-      return null;
-    }
-    if ((/^[A-Z]:/).test(name)) {
-      return null;
-    }
-
-    let fullpath;
-
-    try {
-      fullpath = require.resolve(name);
-    } catch (e) {
-      return null;
-    }
-
-    this.pathsToNames[fullpath] = name;
-
-    const source = {
-      src: fs.readFileSync(fullpath, 'utf-8'),
-      path: fullpath,
-      noCache: this.noCache,
-    };
-
-    this.emit('load', name, source);
-    return source;
+    throw new Error('Filesystem operations are not supported.');
   }
 }
 

--- a/nunjucks/src/precompile.js
+++ b/nunjucks/src/precompile.js
@@ -1,6 +1,5 @@
 'use strict';
 
-const fs = require('fs');
 const path = require('path');
 const {_prettifyError} = require('./lib');
 const compiler = require('./compiler');
@@ -27,80 +26,7 @@ function precompileString(str, opts) {
 }
 
 function precompile(input, opts) {
-  // The following options are available:
-  //
-  // * name: name of the template (auto-generated when compiling a directory)
-  // * isString: input is a string, not a file path
-  // * asFunction: generate a callable function
-  // * force: keep compiling on error
-  // * env: the Environment to use (gets extensions and async filters from it)
-  // * include: which file/folders to include (folders are auto-included, files are auto-excluded)
-  // * exclude: which file/folders to exclude (folders are auto-included, files are auto-excluded)
-  // * wrapper: function(templates, opts) {...}
-  //       Customize the output format to store the compiled template.
-  //       By default, templates are stored in a global variable used by the runtime.
-  //       A custom loader will be necessary to load your custom wrapper.
-
-  opts = opts || {};
-  const env = opts.env || new Environment([]);
-  const wrapper = opts.wrapper || precompileGlobal;
-
-  if (opts.isString) {
-    return precompileString(input, opts);
-  }
-
-  const pathStats = fs.existsSync(input) && fs.statSync(input);
-  const precompiled = [];
-  const templates = [];
-
-  function addTemplates(dir) {
-    fs.readdirSync(dir).forEach((file) => {
-      const filepath = path.join(dir, file);
-      let subpath = filepath.substr(path.join(input, '/').length);
-      const stat = fs.statSync(filepath);
-
-      if (stat && stat.isDirectory()) {
-        subpath += '/';
-        if (!match(subpath, opts.exclude)) {
-          addTemplates(filepath);
-        }
-      } else if (match(subpath, opts.include)) {
-        templates.push(filepath);
-      }
-    });
-  }
-
-  if (pathStats.isFile()) {
-    precompiled.push(_precompile(
-      fs.readFileSync(input, 'utf-8'),
-      opts.name || input,
-      env
-    ));
-  } else if (pathStats.isDirectory()) {
-    addTemplates(input);
-
-    for (let i = 0; i < templates.length; i++) {
-      const name = templates[i].replace(path.join(input, '/'), '');
-
-      try {
-        precompiled.push(_precompile(
-          fs.readFileSync(templates[i], 'utf-8'),
-          name,
-          env
-        ));
-      } catch (e) {
-        if (opts.force) {
-          // Don't stop generating the output if we're
-          // forcing compilation.
-          console.error(e); // eslint-disable-line no-console
-        } else {
-          throw e;
-        }
-      }
-    }
-  }
-
-  return wrapper(precompiled, opts);
+  throw new Error
 }
 
 function _precompile(str, name, env) {


### PR DESCRIPTION
Removing the native filesystem module increases safety during execution of user provided templates.
With this change we can omit the 'fs' dependency entirely in vm2.